### PR TITLE
Remove redundant specs to fix running Atom specs

### DIFF
--- a/spec/flex-toolbar-view-spec.coffee
+++ b/spec/flex-toolbar-view-spec.coffee
@@ -1,5 +1,0 @@
-FlexToolbarView = require '../lib/flex-toolbar-view'
-
-describe "FlexToolbarView", ->
-  it "has one valid test", ->
-    expect("life").toBe "easy"


### PR DESCRIPTION
This will fix running the [Atom specs](https://atom.io/docs/latest/writing-specs): `View` > `Developer` > `Run Atom Specs`.