### PR TITLE
Fix default path for Windows users

### DIFF
--- a/lib/flex-toolbar.coffee
+++ b/lib/flex-toolbar.coffee
@@ -1,5 +1,6 @@
 rootDir = require('../index').getPackageRootDir()
 shell = require 'shell'
+path = require 'path'
 
 module.exports =
   urlholder: ''
@@ -9,7 +10,7 @@ module.exports =
   config:
     toolbarConfigurationJsonPath:
       type: 'string'
-      default: rootDir + '/toolbar.json'
+      default: path.join rootDir, 'toolbar.json'
     showConfigButton:
       type: 'boolean'
       default: true
@@ -27,9 +28,9 @@ module.exports =
       'flex-toolbar:edit-config-file': ->
         atom.workspace.open atom.config.get('flex-toolbar.toolbarConfigurationJsonPath')
 
-  initToolbar:() ->
+  initToolbar: () ->
     atom.packages.activatePackage('toolbar')
-      .then (pkg)=>
+      .then (pkg) =>
         @toolbar = pkg.mainModule
 
         try
@@ -60,4 +61,3 @@ module.exports =
   deactivate: ->
 
   serialize: ->
-


### PR DESCRIPTION
Windows users use a [different](http://www.howtogeek.com/181774/why-windows-uses-backslashes-and-everything-else-uses-forward-slashes/) slash for folder paths. Aldo it currently works, this PR will normalize it for the settings window.

Not
```
Default: C:\Users\xxx\.atom\packages\flex-toolbar/toolbar.json
```
but
```
Default: C:\Users\xxx\.atom\packages\flex-toolbar\toolbar.json
```
