### PR TITLE
Remove redundant css

### DIFF
--- a/styles/flex-toolbar.less
+++ b/styles/flex-toolbar.less
@@ -4,14 +4,6 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-.flex-toolbar {
-}
-
 #toolbar {
-  .icon:hover:before {
-    font-size: 36px;
-  }
-  .icon:hover {
-    cursor: pointer;
-  }
+  
 }


### PR DESCRIPTION
Removed redundant css now that https://github.com/suda/toolbar/pull/15 & https://github.com/suda/toolbar/pull/16 are merged.