### PR TITLE
Use toolbar services API

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,3 +1,0 @@
-module.exports =
-  getPackageRootDir: ->
-    return __dirname

--- a/lib/flex-toolbar.coffee
+++ b/lib/flex-toolbar.coffee
@@ -53,7 +53,7 @@ module.exports =
           when 'button'
             button = @toolbar_addButton btn
           when 'spacer'
-            button = @toolbar.addSpacer()
+            button = @toolbar.addSpacer priority: btn.priority
           when 'url'
             button = @toolbar.addButton
               icon: btn.icon
@@ -62,6 +62,7 @@ module.exports =
               tooltip: btn.tooltip
               iconset: btn.iconset
               data: btn.url
+              priority: btn.priority
         button.addClass "tool-bar-mode-#{btn.mode}" if btn.mode
 
   toolbar_addButton: (btn) ->
@@ -73,12 +74,14 @@ module.exports =
             atom.commands.dispatch document.activeElement, callback
         tooltip: btn.tooltip
         iconset: btn.iconset
+        priority: btn.priority
     else
       @toolbar.addButton
         icon: btn.icon
         callback: btn.callback
         tooltip: btn.tooltip
         iconset: btn.iconset
+        priority: btn.priority
 
   removeButtons: ->
     @toolbar.removeItems()

--- a/lib/flex-toolbar.coffee
+++ b/lib/flex-toolbar.coffee
@@ -57,7 +57,7 @@ module.exports =
             button = @toolbar.addButton
               icon: btn.icon
               callback: (url) ->
-                shell.openExternal(url)
+                shell.openExternal url
               tooltip: btn.tooltip
               iconset: btn.iconset
               data: btn.url
@@ -65,7 +65,7 @@ module.exports =
 
   toolbar_addButton: (btn) ->
     if Array.isArray btn.callback
-      button = @toolbar.addButton
+      @toolbar.addButton
         icon: btn.icon
         callback: (callbacks) ->
           for callback in callbacks
@@ -73,16 +73,14 @@ module.exports =
         tooltip: btn.tooltip
         iconset: btn.iconset
     else
-      button = @toolbar.addButton
+      @toolbar.addButton
         icon: btn.icon
         callback: btn.callback
         tooltip: btn.tooltip
         iconset: btn.iconset
-    button
 
   removeButtons: ->
-    {$} = require 'space-pen'
-    $(".tool-bar").empty()
+    @toolbar.removeItems()
 
   deactivate: ->
     @subscriptions.dispose()

--- a/lib/flex-toolbar.coffee
+++ b/lib/flex-toolbar.coffee
@@ -25,7 +25,7 @@ module.exports =
         @reloadToolbar()
 
   consumeToolBar: (toolbar) ->
-    @toolbar = toolbar
+    @toolbar = toolbar 'flex-toolbar'
     @reloadToolbar()
 
   reloadToolbar: () ->
@@ -36,7 +36,10 @@ module.exports =
       @removeButtons()
       @addButtons toolbarButtons
       if atom.config.get('flex-toolbar.showConfigButton')
-        @toolbar.addButton 'gear', 'flex-toolbar:edit-config-file', 'Edit toolbar'
+        @toolbar.addButton
+          icon: 'gear'
+          callback: 'flex-toolbar:edit-config-file'
+          tooltip: 'Edit toolbar'
     catch error
       console.debug 'JSON is not valid'
 
@@ -47,20 +50,35 @@ module.exports =
         continue if btn.mode and btn.mode is 'dev' and not devMode
         switch btn.type
           when 'button'
-            if Array.isArray btn.callback
-              button = @toolbar.addButton btn.icon, (callbacks) ->
-                for callback in callbacks
-                  atom.commands.dispatch document.activeElement, callback
-              , btn.tooltip, btn.iconset, btn.callback
-            else
-              button = @toolbar.addButton btn.icon, btn.callback, btn.tooltip, btn.iconset
+            button = @toolbar_addButton btn
           when 'spacer'
             button = @toolbar.addSpacer()
           when 'url'
-            button = @toolbar.addButton btn.icon, (url) ->
-              shell.openExternal(url)
-            , btn.tooltip, btn.iconset, btn.url
+            button = @toolbar.addButton
+              icon: btn.icon
+              callback: (url) ->
+                shell.openExternal(url)
+              tooltip: btn.tooltip
+              iconset: btn.iconset
+              data: btn.url
         button.addClass "tool-bar-mode-#{btn.mode}" if btn.mode
+
+  toolbar_addButton: (btn) ->
+    if Array.isArray btn.callback
+      button = @toolbar.addButton
+        icon: btn.icon
+        callback: (callbacks) ->
+          for callback in callbacks
+            atom.commands.dispatch document.activeElement, callback
+        tooltip: btn.tooltip
+        iconset: btn.iconset
+    else
+      button = @toolbar.addButton
+        icon: btn.icon
+        callback: btn.callback
+        tooltip: btn.tooltip
+        iconset: btn.iconset
+    button
 
   removeButtons: ->
     {$} = require 'space-pen'

--- a/lib/flex-toolbar.coffee
+++ b/lib/flex-toolbar.coffee
@@ -40,6 +40,7 @@ module.exports =
           icon: 'gear'
           callback: 'flex-toolbar:edit-config-file'
           tooltip: 'Edit toolbar'
+        @toolbar.addSpacer()
     catch error
       console.debug 'JSON is not valid'
 

--- a/lib/flex-toolbar.coffee
+++ b/lib/flex-toolbar.coffee
@@ -1,9 +1,7 @@
-rootDir = require('../index').getPackageRootDir()
 shell = require 'shell'
 path = require 'path'
 
 module.exports =
-
   toolbar: null
 
   config:

--- a/lib/flex-toolbar.coffee
+++ b/lib/flex-toolbar.coffee
@@ -60,7 +60,7 @@ module.exports =
             button = @toolbar.addButton btn.icon, (url) ->
               shell.openExternal(url)
             , btn.tooltip, btn.iconset, btn.url
-        button.addClass 'tool-bar-mode-' + btn.mode if btn.mode
+        button.addClass "tool-bar-mode-#{btn.mode}" if btn.mode
 
   removeButtons: ->
     {$} = require 'space-pen'

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "repository": "https://github.com/cakecatz/flex-toolbar",
   "license": "MIT",
   "keywords": [
-    "toolbar"
+    "toolbar",
+    "tool-bar"
   ],
   "engines": {
-    "atom": ">=0.174.0 <2.0.0"
+    "atom": ">=0.188.0 <2.0.0"
   },
   "dependencies": {
     "atom-package-dependencies": "latest",
@@ -17,6 +18,13 @@
     "space-pen": "^5.1.1"
   },
   "package-dependencies": {
-    "toolbar": "This is COOL package :D"
+    "toolbar": "^0.1.0"
+  },
+  "consumedServices": {
+    "tool-bar": {
+      "versions": {
+        "^0.1.0": "consumeToolBar"
+      }
+    }
   }
 }


### PR DESCRIPTION
Ref: https://github.com/suda/toolbar/pull/34

* [x] :sparkles: Implement toolbar service API
  * [x] Use `addButton()` & `addSpacer()` and convert options to object
  * [x] Use `removeItems()`
  * [x] Removed `initToolbar()` in favor of `reloadToolbar()`
  * [x] :package: Increase atom engine semver required for services API
* [x] :fire: Removed redundant `rootDir` property and `index.coffee` file
* [x] :sparkles: Add spacer after edit-toolbar button

~~Do not merge until https://github.com/suda/toolbar/pull/34 is merged. :smile:~~ Merged.