### PR TITLE
Notifications on toolbar edit

### DIFF
--- a/lib/flex-toolbar.coffee
+++ b/lib/flex-toolbar.coffee
@@ -26,9 +26,9 @@ module.exports =
 
   consumeToolBar: (toolbar) ->
     @toolbar = toolbar 'flex-toolbar'
-    @reloadToolbar()
+    @reloadToolbar true
 
-  reloadToolbar: () ->
+  reloadToolbar: (init) ->
     try
       toolbarButtons = require atom.config.get('flex-toolbar.toolbarConfigurationJsonPath')
       delete require.cache[atom.config.get('flex-toolbar.toolbarConfigurationJsonPath')]
@@ -41,7 +41,9 @@ module.exports =
           callback: 'flex-toolbar:edit-config-file'
           tooltip: 'Edit toolbar'
         @toolbar.addSpacer()
+      atom.notifications.addSuccess 'The tool-bar was successfully updated.' if not init
     catch error
+      atom.notifications.addError 'Your `toolbar.json` is **not valid JSON**!' if not init
       console.debug 'JSON is not valid'
 
   addButtons: (toolbarButtons) ->


### PR DESCRIPTION
This PR adds success and error notifications after editing the `toolbar.json` file.

![success](https://cloud.githubusercontent.com/assets/55841/7444889/0122ecd2-f19a-11e4-94fe-dc468ffd57ba.png)
![error](https://cloud.githubusercontent.com/assets/55841/7444890/04d4a46a-f19a-11e4-867e-16d30c8ee82d.png)
