### PR TITLE
Fixed resolveConfigPath not searching for toolbar.json

### DIFF
--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -111,7 +111,8 @@ module.exports =
     @configFilePath = atom.config.get('flex-tool-bar.toolBarConfigurationFilePath')
     
     if !fs.isFileSync @configFilePath
-      @configFilePath = fs.resolve process.env.ATOM_HOME, 'toolbar', ['cson', 'json5', 'json']
+      config_dir = process.env.ATOM_HOME
+      @configFilePath = fs.resolve config_dir, 'toolbar', ['cson', 'json5', 'json']
 
   loadConfig: ->
     ext = path.extname @configFilePath

--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -110,10 +110,8 @@ module.exports =
     fs = require 'fs-plus'
     @configFilePath = atom.config.get('flex-tool-bar.toolBarConfigurationFilePath')
     
-    ext = path.extname @configFilePath
-
-    if ext is ''
-      @configFilePath = fs.resolve @configFilePath, 'toolbar', ['cson', 'json5', 'json']
+    if !fs.isFileSync @configFilePath
+      @configFilePath = fs.resolve process.env.ATOM_HOME, 'toolbar', ['cson', 'json5', 'json']
 
   loadConfig: ->
     ext = path.extname @configFilePath


### PR DESCRIPTION
A quick fix to ensure that when the config file is not toolbar.cson the resolveConfigPath() function will search for the configuration file using the names toolbar.json and toolbar.json5

