### PR TITLE
Look for specific file in hide/show keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To edit your config file, type `Flex Toolbar: Edit my config file` in the Atom c
 
 ### Configuration
 
-**Flex Tool Bar** has three "types" you can configure:
+**Flex Tool Bar** has three `type`s you can configure:
 `button`, `url` and `spacer`.
 
 - `button` creates default buttons for your toolbar.
@@ -24,8 +24,8 @@ To edit your config file, type `Flex Toolbar: Edit my config file` in the Atom c
 - `url` creates buttons pointing to specific web pages.
 
     Use this to open any web site, such as your GitHub notifications, in your default browser. See this feature in action in this [screencast](http://quick.as/b5vafe4g).
-    
-    If you have the package [browser-plus](https://atom.io/packages/browser-plus) installed, you can use its in Atom browser to open your links. Just check the box in flex-toolbars settings.
+
+    If you have the package [browser-plus](https://atom.io/packages/browser-plus) installed, you can use it to open your links. Just check the box in flex-toolbar's settings.
 
 - `spacer` adds separators between toolbar buttons.
 
@@ -33,86 +33,103 @@ To edit your config file, type `Flex Toolbar: Edit my config file` in the Atom c
 
 - multiple callback
 - button style
-- hide, disable button when specific grammar
+- hide/disable a button in certain cases
 
 ### Button style
 
 Can use CSS Property.
-
-    style: {
-      color: "red"
-      background: "green"
-      border: "1px solid blue"
-    }
+```coffeescript
+style: {
+  color: "red"
+  background: "green"
+  border: "1px solid blue"
+}
+```
 
 ### Multiple callback
-
-    callback: ["callback1", "callback2"]
+```coffeescript
+callback: ["callback1", "callback2"]
+```
 
 ### Hide(Show), Disable(Enable) button
 
-You can hide or disable button when specific grammar.
-If you set like this,
+You can hide or disable buttons when a certain grammar is used in the active file or a specified file is matched.
 
-    disable: "coffee"
+If you set `disable` (`show`, `disable` or `enable`) this way:
+```coffeescript
+disable: "coffee"
+```
 
-Will disable button when opened CoffeeScript file.
+It will disable the button if a CoffeeScript file is open.
 
-Of course, can set Array to value.
+You can also look for a specific file using:
+```coffeescript
+disable: "./gulpfile.js"
+```
 
-    disable: [
-      "json"
-      "less"
-    ]
+The package uses [Glob](https://github.com/isaacs/node-glob), that is based on [minimatch](https://github.com/isaacs/minimatch), follow its [*syntax*](https://github.com/isaacs/node-glob#glob-primer).
+
+
+
+Of course, you can set it as an array.
+```coffeescript
+disable: [
+  "json"
+  "less"
+]
+```
 
 You can use `!` :laughing:
-
-    hide: "!Markdown"
+```coffeescript
+hide: "!Markdown"
+```
 
 This will hide button when opened any file except Markdown.
-
-    show: "Markdown"
+```coffeescript
+show: "Markdown"
+```
 
 This is same above.
 
 
 ### Sample Code
-
-    [
-      {
-        type: "url"
-        icon: "octoface"
-        url: "http://github.com"
-        tooltip: "Github Page"
-      }
-      {
-        type: "spacer"
-      }
-      {
-        type: "button"
-        icon: "document"
-        callback: "application:new-file"
-        tooltip: "New File"
-        iconset: "ion"
-        mode: "dev"
-      }
-      {
-        type: "button"
-        icon: "columns"
-        iconset: "fa"
-        callback: ["pane:split-right", "pane:split-right"]
-      }
-      {
-        type: "button"
-        icon: "circuit-board"
-        callback: "git-diff:toggle-diff-list"
-        style:
-          color: "#FA4F28"
-      }
-      {
-        type: "button"
-        icon: "markdown"
-        callback: "markdown-preview:toggle"
-        disable: "!markdown"
-      }
-    ]
+```coffeescript
+[
+  {
+    type: "url"
+    icon: "octoface"
+    url: "http://github.com"
+    tooltip: "Github Page"
+  }
+  {
+    type: "spacer"
+  }
+  {
+    type: "button"
+    icon: "document"
+    callback: "application:new-file"
+    tooltip: "New File"
+    iconset: "ion"
+    mode: "dev"
+  }
+  {
+    type: "button"
+    icon: "columns"
+    iconset: "fa"
+    callback: ["pane:split-right", "pane:split-right"]
+  }
+  {
+    type: "button"
+    icon: "circuit-board"
+    callback: "git-diff:toggle-diff-list"
+    style:
+      color: "#FA4F28"
+  }
+  {
+    type: "button"
+    icon: "markdown"
+    callback: "markdown-preview:toggle"
+    disable: "!markdown"
+  }
+]
+```

--- a/README.md
+++ b/README.md
@@ -55,19 +55,26 @@ callback: ["callback1", "callback2"]
 
 You can hide or disable buttons when a certain grammar is used in the active file or a specified file is matched.
 
-If you set `disable` (`show`, `disable` or `enable`) this way:
+If you set `disable` (`show`, `hide` or `enable`) this way:
 ```coffeescript
 disable: "coffee"
 ```
 
 It will disable the button if a CoffeeScript file is open.
 
-You can also look for a specific file using:
+You can also look for a specific file using [globs](https://tr.im/glob):
 ```coffeescript
-disable: "./gulpfile.js"
+show: {
+  pattern: 'gulpfile.js'
+  options: {
+    maxDepth: 2
+  }
+}
 ```
 
-The package uses [Glob](https://github.com/isaacs/node-glob), that is based on [minimatch](https://github.com/isaacs/minimatch), follow its [*syntax*](https://github.com/isaacs/node-glob#glob-primer).
+The package uses [tree-match-sync](https://github.com/boredz/tree-match-sync) that depends on the `tree` command, [install it](https://github.com/boredz/tree-match-sync#installation) before using this feature.
+
+The options are explained [here](https://github.com/isaacs/minimatch#options) and it has an extra field: `maxDepth`, it translates to `tree`'s option `-L`, you should always set it.
 
 
 

--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -134,26 +134,28 @@ module.exports =
     result = false
     grammarType = Object.prototype.toString.call grammars
     grammars = [grammars] if grammarType is '[object String]' or grammarType is '[object Object]'
+    filePath = atom.workspace.getActiveTextEditor().getPath()
 
     for grammar in grammars
-      reverse  = false
+      reverse = false
+
       if Object.prototype.toString.call(grammar) is '[object Object]'
+        if filePath is undefined
+          continue
+
         activePath = @getActiveProject()
         options = if grammar.options then grammar.options else {}
         tree = treeMatch activePath, grammar.pattern, options
-        console.log tree
-
-        result = true if Object.prototype.toString.call(tree) is '[object Array]' and tree.length > 0
-        console.log result
+        return true if Object.prototype.toString.call(tree) is '[object Array]' and tree.length > 0
       else
         if /^!/.test grammar
           grammar = grammar.replace '!', ''
           reverse = true
 
         if /^[^\/]+\.(.*?)$/.test grammar
-          result = true if atom.workspace.getActiveTextEditor().getPath().match(grammar)?.length > 0
-        else if @currentGrammar? && @currentGrammar.includes grammar.toLowerCase()
-          result = true
+          result = true if filePath isnt undefined and filePath.match(grammar)?.length > 0
+        else
+          result = true if @currentGrammar? and @currentGrammar.includes grammar.toLowerCase()
 
       result = !result if reverse
 

--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -2,6 +2,7 @@ shell = require 'shell'
 path = require 'path'
 fs = require 'fs-plus'
 treeMatch = require 'tree-match-sync'
+treeIsInstalled = treeMatch.treeIsInstalled()
 module.exports =
   toolBar: null
   configFilePath: null
@@ -140,6 +141,10 @@ module.exports =
       reverse = false
 
       if Object.prototype.toString.call(grammar) is '[object Object]'
+        if !treeIsInstalled
+          atom.notifications.addError '[Tree](http://mama.indstate.edu/users/ice/tree/) is not installed, please install it.'
+          continue
+
         if filePath is undefined
           continue
 

--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -126,7 +126,7 @@ module.exports =
 
     for grammar in grammars
       reverse  = false
-      if grammar.includes '!'
+      if /^!/.test grammar
         grammar = grammar.replace '!', ''
         reverse = true
 

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "dependencies": {
     "cson": "^3.0.2",
     "fs-plus": "^2.8.1",
-    "glob": "^5.0.15",
     "json5": "^0.4.0",
     "node-watch": "^0.3.4",
-    "space-pen": "^5.1.1"
+    "space-pen": "^5.1.1",
+    "tree-match-sync": "0.0.1"
   },
   "package-dependencies": {
     "tool-bar": "^0.1.9"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "cson": "^3.0.2",
     "fs-plus": "^2.8.1",
+    "glob": "^5.0.15",
     "json5": "^0.4.0",
     "node-watch": "^0.3.4",
     "space-pen": "^5.1.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "json5": "^0.4.0",
     "node-watch": "^0.3.4",
     "space-pen": "^5.1.1",
-    "tree-match-sync": "0.0.1"
+    "tree-match-sync": "0.0.2"
   },
   "package-dependencies": {
     "tool-bar": "^0.1.9"


### PR DESCRIPTION
I've installed the [gulp-control](https://atom.io/packages/gulp-control) package and added it to my toolbar, but I can make it visible only in JS files.
It would be nice if we could write in the `hide`, `show`, `disable` and `enable` keys a string that can look for a specific file (eg: `./**/gulpfile.[js|coffee]`) in the actual project folder :smile: