### PR TITLE
Do not pass true param to reloadToolbar from consumeToolBar.  Fixes #60

### DIFF
--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -29,7 +29,7 @@ module.exports =
     @registerEvent()
     @registerWatch()
 
-    @reloadToolbar(true)
+    @reloadToolbar(false)
 
   resolveConfigPath: ->
     @configFilePath = atom.config.get 'flex-tool-bar.toolBarConfigurationFilePath'
@@ -85,7 +85,7 @@ module.exports =
     if atom.config.get('flex-tool-bar.reloadToolBarWhenEditConfigFile')
       watch = require 'node-watch'
       watch @configFilePath, =>
-        @reloadToolbar()
+        @reloadToolbar(true)
 
   registerTypes: ->
     typeFiles = fs.listSync path.join __dirname, '../types'
@@ -95,7 +95,7 @@ module.exports =
 
   consumeToolBar: (toolBar) ->
     @toolBar = toolBar 'flex-toolBar'
-    @reloadToolbar
+    @reloadToolbar(false)
 
   reloadToolbar: (withNotification=false) ->
     return unless @toolBar?

--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -95,7 +95,7 @@ module.exports =
 
   consumeToolBar: (toolBar) ->
     @toolBar = toolBar 'flex-toolBar'
-    @reloadToolbar true
+    @reloadToolbar
 
   reloadToolbar: (withNotification=false) ->
     return unless @toolBar?


### PR DESCRIPTION
Fix redundant update message on every Atom start.

Toggle the withNotification argument on the following lines:

L32 to remove notification on package activation.
L88 to show the notificaction when file has changed.
L98 to remove notification on service connection.