### PR TITLE
Add support for 'bookmark' button type

### DIFF
--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -120,42 +120,8 @@ module.exports =
 
         continue if btn.mode and btn.mode is 'dev' and not devMode
 
-        switch btn.type
-          when 'button'
-            button = @toolBar_addButton btn
-          when 'spacer'
-            button = @toolBar.addSpacer priority: btn.priority
-          when 'url'
-            button = @toolBar.addButton
-              icon: btn.icon
-              callback: (url) =>
-                urlReplace = new UrlReplace()
-                url = urlReplace.replace url
-                if atom.config.get('flex-tool-bar.useBrowserPlusWhenItIsActive')
-                  if atom.packages.isPackageActive('browser-plus')
-                    atom.workspace.open url, split:'right'
-                  else
-                    warning = "Package browser-plus is not active. Using default browser instead!"
-                    options = detail: "Use apm install browser-plus to install the needed package."
-                    atom.notifications.addWarning warning, options
-                    shell.openExternal url
-                else
-                  shell.openExternal url
-              tooltip: btn.tooltip
-              iconset: btn.iconset
-              data: btn.url
-              priority: btn.priority
-          when 'bookmark'
-            button = @toolBar.addButton
-              icon: btn.icon
-              iconset: btn.iconset
-              tooltip: btn.tooltip
-              data: btn.url
-              priority: btn.priority
-              callback: (url) =>
-                urlReplace = new UrlReplace()
-                url = urlReplace.replace url
-                atom.workspace.open (url)
+        button = @buttonTypes[btn.type](@toolBar, btn) if @buttonTypes[btn.type]
+
         button.addClass "tool-bar-mode-#{btn.mode}" if btn.mode
 
         if btn.style?

--- a/types/bookmark.coffee
+++ b/types/bookmark.coffee
@@ -1,0 +1,13 @@
+UrlReplace = require '../lib/url-replace'
+
+module.exports = (toolBar, button) ->
+  return toolBar.addButton
+    icon: button.icon
+    callback: (url) ->
+      urlReplace = new UrlReplace()
+      url = urlReplace.replace url
+      atom.workspace.open (url)
+    tooltip: button.tooltip
+    iconset: button.iconset
+    data: button.url
+    priority: button.priority or 45


### PR DESCRIPTION
With this pull request, Flex Tool Bar buttons can be added that open files in Atom, as well as all of the existing types (button, url, spacer):

```cson
[
  {
    type: "url"
    icon: "octoface"
    url: "https://github.com/"
    tooltip: "GitHub"
  }
  {
    type: "spacer"
  }
  {
    type: "button"
    iconset: "ion"
    icon: "document"
    callback: "application:new-file"
    tooltip: "New File"
  }
  # New Button Types (bookmark):
  {
    type: "bookmark"
    iconset: "fa"
    icon: "book"
    url: "README.md"
    tooltip: "View Documentation"
  }
  {
    type: "bookmark"
    icon: "tools"
    url: "/Users/username/.atom/toolbar.cson"
    tooltip: "Open Flex Toolbar Config"
    style: {
      color: "red"
      background: "transparent"
      border: "none"
    }
    mode: "dev"
  }
  ...
]
```

This feature was inspired by @ruicosta042 in Issue #47.