### PR TITLE
Fix undefined rootDirectories in 1.9.0-beta0. Fixes #76

### DIFF
--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -88,10 +88,10 @@ module.exports =
     editor = atom.workspace.getActiveTextEditor()
 
     if editor?.buffer?.file?.getParent()?.path?
-      projectCount = editor.project.rootDirectories.length
+      projectCount = atom.project.getPaths().length
       count = 0
       while count < projectCount
-        pathToCheck = editor.project.rootDirectories[count].path
+        pathToCheck = atom.project.getPaths()[count]
         if editor.buffer.file.getParent().path.includes(pathToCheck)
           @projectToolbarConfigPath = fs.resolve pathToCheck, 'toolbar', ['cson', 'json5', 'json']
         count++


### PR DESCRIPTION
Proposed fix for #76

Aldo I think more should be changed to official API's, e.g. [`editor?.buffer?.file?.getParent()?.path?`](https://github.com/cakecatz/flex-toolbar/blob/master/lib/flex-tool-bar.coffee#L90)