### PR TITLE
Allow custom function as callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ type `Flex Tool Bar: Edit Config File` in the Atom command palette.
 
 -   `function` creates buttons that can call a function with the previous target as a parameter
 
-    This requires the config file to be a `.js` or `.coffee` file that exports a function that returns the array of buttons
+    This requires the config file to be a `.js` or `.coffee` file that exports the array of buttons
 
 -   `spacer` adds separators between toolbar buttons.
 
@@ -176,55 +176,54 @@ This is same above.
 ### .coffee Example
 
 ```coffeescript
-module.exports = ->
-  [
-    {
-      type: "function"
-      icon: "bug"
-      callback: (target) ->
-        console.dir target
-      tooltip: "Debug Target"
-    }
-    {
-      type: "spacer"
-    }
-    {
-      type: "url"
-      icon: "octoface"
-      url: "https://github.com/"
-      tooltip: "Github Page"
-    }
-    {
-      type: "spacer"
-    }
-    {
-      type: "button"
-      icon: "document"
-      callback: "application:new-file"
-      tooltip: "New File"
-      iconset: "ion"
-      mode: "dev"
-    }
-    {
-      type: "button"
-      icon: "columns"
-      iconset: "fa"
-      callback: ["pane:split-right", "pane:split-right"]
-    }
-    {
-      type: "button"
-      icon: "circuit-board"
-      callback: "git-diff:toggle-diff-list"
-      style:
-        color: "#FA4F28"
-    }
-    {
-      type: "button"
-      icon: "markdown"
-      callback: "markdown-preview:toggle"
-      disable: "!markdown"
-    }
-  ]
+module.exports = [
+  {
+    type: "function"
+    icon: "bug"
+    callback: (target) ->
+      console.dir target
+    tooltip: "Debug Target"
+  }
+  {
+    type: "spacer"
+  }
+  {
+    type: "url"
+    icon: "octoface"
+    url: "https://github.com/"
+    tooltip: "Github Page"
+  }
+  {
+    type: "spacer"
+  }
+  {
+    type: "button"
+    icon: "document"
+    callback: "application:new-file"
+    tooltip: "New File"
+    iconset: "ion"
+    mode: "dev"
+  }
+  {
+    type: "button"
+    icon: "columns"
+    iconset: "fa"
+    callback: ["pane:split-right", "pane:split-right"]
+  }
+  {
+    type: "button"
+    icon: "circuit-board"
+    callback: "git-diff:toggle-diff-list"
+    style:
+      color: "#FA4F28"
+  }
+  {
+    type: "button"
+    icon: "markdown"
+    callback: "markdown-preview:toggle"
+    disable: "!markdown"
+  }
+]
 ```
 
 ### Per Project Configuration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This is a plugin for
 the [Atom Tool Bar](https://atom.io/packages/tool-bar) package.
 
-You can configure your toolbar buttons with a `CSON`, `JSON`, `JSON5` file
+You can configure your toolbar buttons with a `CSON`, `JSON`, `JSON5`, `js`, `coffee` file
 to perform specific actions in Atom
 or to open web sites in your default browser.
 
@@ -18,8 +18,8 @@ type `Flex Tool Bar: Edit Config File` in the Atom command palette.
 
 ## Configuration
 
-**Flex Tool Bar** has three `type`s you can configure:
-`button`, `url` and `spacer`.
+**Flex Tool Bar** has four `type`s you can configure:
+`button`, `url`, `function` and `spacer`.
 
 -   `button` creates default buttons for your toolbar.
 
@@ -37,11 +37,16 @@ type `Flex Tool Bar: Edit Config File` in the Atom command palette.
     Also Atom URI are allowed. For example
     `atom://config/packages/flex-tool-bar` will open Flex Tool Bar's settings.
 
+-   `function` creates buttons that can call a function with the previous target as a parameter
+
+    This requires the config file to be a `.js` or `.coffee` file that exports a function that returns the array of buttons
+
 -   `spacer` adds separators between toolbar buttons.
 
 ### Features
 
 -   multiple callback
+-   function callback
 -   button style
 -   hide/disable a button in certain cases
 
@@ -61,6 +66,13 @@ style: {
 
 ```coffeescript
 callback: ["callback1", "callback2"]
+```
+
+### Function callback
+
+```coffeescript
+callback: target ->
+  console.log target
 ```
 
 ### Hide(Show), Disable(Enable) button
@@ -118,7 +130,7 @@ show: "Markdown"
 
 This is same above.
 
-### Example
+### .cson Example
 
 ```coffeescript
 [
@@ -159,6 +171,60 @@ This is same above.
     disable: "!markdown"
   }
 ]
+```
+
+### .coffee Example
+
+```coffeescript
+module.exports = ->
+  [
+    {
+      type: "function"
+      icon: "bug"
+      callback: (target) ->
+        console.dir target
+      tooltip: "Debug Target"
+    }
+    {
+      type: "spacer"
+    }
+    {
+      type: "url"
+      icon: "octoface"
+      url: "https://github.com/"
+      tooltip: "Github Page"
+    }
+    {
+      type: "spacer"
+    }
+    {
+      type: "button"
+      icon: "document"
+      callback: "application:new-file"
+      tooltip: "New File"
+      iconset: "ion"
+      mode: "dev"
+    }
+    {
+      type: "button"
+      icon: "columns"
+      iconset: "fa"
+      callback: ["pane:split-right", "pane:split-right"]
+    }
+    {
+      type: "button"
+      icon: "circuit-board"
+      callback: "git-diff:toggle-diff-list"
+      style:
+        color: "#FA4F28"
+    }
+    {
+      type: "button"
+      icon: "markdown"
+      callback: "markdown-preview:toggle"
+      disable: "!markdown"
+    }
+  ]
 ```
 
 ### Per Project Configuration

--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -196,7 +196,7 @@ module.exports =
 
     switch ext
       when '.js', '.coffee'
-        config = require(@configFilePath)()
+        config = require(@configFilePath)
         delete require.cache[@configFilePath]
 
       when '.json'
@@ -217,7 +217,7 @@ module.exports =
 
       switch ext
         when '.js', '.coffee'
-          projConfig = require(@projectToolbarConfigPath)()
+          projConfig = require(@projectToolbarConfigPath)
           delete require.cache[@projectToolbarConfigPath]
 
         when '.json'

--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -49,9 +49,9 @@ module.exports =
     # Default directory
     @configFilePath = process.env.ATOM_HOME unless @configFilePath
 
-    # If configFilePath is a folder, check for `toolbar.(json|cson|json5)` file
+    # If configFilePath is a folder, check for `toolbar.(json|cson|json5|js|coffee)` file
     unless fs.isFileSync(@configFilePath)
-      @configFilePath = fs.resolve @configFilePath, 'toolbar', ['cson', 'json5', 'json']
+      @configFilePath = fs.resolve @configFilePath, 'toolbar', ['cson', 'json5', 'json', 'js', 'coffee']
 
     return true if @configFilePath
 
@@ -94,7 +94,7 @@ module.exports =
       while count < projectCount
         pathToCheck = atom.project.getPaths()[count]
         if editor.buffer.file.getParent().path.includes(pathToCheck)
-          @projectToolbarConfigPath = fs.resolve pathToCheck, 'toolbar', ['cson', 'json5', 'json']
+          @projectToolbarConfigPath = fs.resolve pathToCheck, 'toolbar', ['cson', 'json5', 'json', 'js', 'coffee']
         count++
 
     if @projectToolbarConfigPath is @configFilePath
@@ -195,6 +195,10 @@ module.exports =
     ext = path.extname @configFilePath
 
     switch ext
+      when '.js', '.coffee'
+        config = require(@configFilePath)()
+        delete require.cache[@configFilePath]
+
       when '.json'
         config = require @configFilePath
         delete require.cache[@configFilePath]
@@ -212,6 +216,10 @@ module.exports =
       ext = path.extname @projectToolbarConfigPath
 
       switch ext
+        when '.js', '.coffee'
+          projConfig = require(@projectToolbarConfigPath)()
+          delete require.cache[@projectToolbarConfigPath]
+
         when '.json'
           projConfig = require @projectToolbarConfigPath
           delete require.cache[@projectToolbarConfigPath]

--- a/types/function.coffee
+++ b/types/function.coffee
@@ -1,0 +1,11 @@
+module.exports = (toolBar, button) ->
+  options =
+    icon: button.icon
+    tooltip: button.tooltip
+    iconset: button.iconset
+    priority: button.priority or 45
+    data: button.callback
+    callback: (data, target) ->
+      data(target)
+
+  return toolBar.addButton options


### PR DESCRIPTION
In order to allow a function as an argument I had to add the .js and .coffee extensions since a function is not a valid type for `JSON(5)` or `CSON`

The alternative would be to use [loophole](https://github.com/atom/loophole) to eval the callback property on the function type if `button.callback` were a string but I decided against that.

fixes #84 
