### PR TITLE
Added feature: Class Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ type `Flex Tool Bar: Edit Config File` in the Atom command palette.
 
 -   multiple callback
 -   function callback
--   button style
+-   add inline button styles
+-   add class(s) to buttons
 -   hide/disable a button in certain cases
 
 ### Button style
 
-Can use CSS Property.
+You can use CSS styles per button.
 
 ```coffeescript
 style: {
@@ -60,6 +61,16 @@ style: {
   background: "green"
   border: "1px solid blue"
 }
+```
+
+### Button style
+
+Using a comma separated list you can add your own class names to buttons.
+This is great if you want to take advantage of native styles like Font Awesome
+or if you have your own styles you prefer to keep in a stylesheet.
+
+```coffeescript
+className: "fa-rotate-90, custom-class"
 ```
 
 ### Multiple callback
@@ -170,6 +181,13 @@ This is same above.
     callback: "markdown-preview:toggle"
     disable: "!markdown"
   }
+  {
+    type: "button"
+    icon: "sitemap"
+    iconset: "fa"
+    className: "fa-rotate-180"
+    tooltip: "This is just an example it does nothing"
+  }
 ]
 ```
 
@@ -222,6 +240,13 @@ module.exports = [
     icon: "markdown"
     callback: "markdown-preview:toggle"
     disable: "!markdown"
+  }
+  {
+    type: "button"
+    icon: "sitemap"
+    iconset: "fa"
+    className: "fa-rotate-180"
+    tooltip: "This is just an example it does nothing"
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ type `Flex Tool Bar: Edit Config File` in the Atom command palette.
 
 -   multiple callback
 -   function callback
--   add inline button styles
+-   inline button styles
 -   add class(s) to buttons
 -   hide/disable a button in certain cases
 
@@ -63,7 +63,7 @@ style: {
 }
 ```
 
-### Button style
+### Button class
 
 Using a comma separated list you can add your own class names to buttons.
 This is great if you want to take advantage of native styles like Font Awesome

--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -188,6 +188,11 @@ module.exports =
           for propName, v of btn.style
             button.element.style[changeCase.camelCase(propName)] = v
 
+        if btn.className?
+          ary = btn.className.split ","
+          for val in ary
+            button.element.classList.add val.trim()
+
         if ( btn.disable? && @grammarCondition(btn.disable) ) or ( btn.enable? && !@grammarCondition(btn.enable) )
           button.setEnabled false
 


### PR DESCRIPTION
I added the ability for users to attach their own class names to buttons. They do this like so:

```coffeescript
className: "fa-rotate-90"
```

or if they would like to add multiple classes to the same button:

```coffeescript
className: "fa-rotate-90, custom-class"
```

This allows users to easily apply some native styles like the `fa-rotate-*` styles from Font Awesome as well as remove the styling from their toolbar configuration file if they prefer to manage it in their own style sheet(s). 

To test my changes add lines `191 - 194` from the `lib/flex-tool-bar.coffee` file into your package and then paste the following into your `toolbar.cson`:

```coffeescript
{
    type: "button"
    icon: "sitemap"
    iconset: "fa"
    className: "fa-rotate-180"
    tooltip: "This is just an example it does nothing"
}
{
    type: "button"
    icon: "sitemap"
    iconset: "fa"
    tooltip: "This is just an example it does nothing"
}
```

I have also updated the README to show examples of this new feature.