### PR TITLE
Added setting to modify the per project configuration file path

### DIFF
--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -17,6 +17,9 @@ module.exports =
     toolBarConfigurationFilePath:
       type: 'string'
       default: atom.getConfigDirPath()
+    toolBarProjectConfigurationFilePath:
+      type: 'string'
+      default: '.'
     reloadToolBarWhenEditConfigFile:
       type: 'boolean'
       default: true
@@ -99,13 +102,18 @@ module.exports =
 
   resolveProjectConfigPath: ->
     @projectToolbarConfigPath = null
+    relativeProjectConfigPath = atom.config.get 'flex-tool-bar.toolBarProjectConfigurationFilePath'
     editor = atom.workspace.getActivePaneItem()
     file = editor?.buffer?.file or editor?.file
 
     if file?.getParent()?.path?
       for pathToCheck in atom.project.getPaths()
         if file.getParent().path.includes(pathToCheck)
-          @projectToolbarConfigPath = fs.resolve pathToCheck, 'toolbar', ['cson', 'json5', 'json', 'js', 'coffee']
+          pathToCheck = path.join pathToCheck, relativeProjectConfigPath
+          if fs.isFileSync(pathToCheck)
+            @projectToolbarConfigPath = pathToCheck
+          else
+            @projectToolbarConfigPath = fs.resolve pathToCheck, 'toolbar', ['cson', 'json5', 'json', 'js', 'coffee']
 
     if @projectToolbarConfigPath is @configFilePath
       @projectToolbarConfigPath = null

--- a/spec/flex-tool-bar-spec.js
+++ b/spec/flex-tool-bar-spec.js
@@ -179,6 +179,30 @@ describe('FlexToolBar', function () {
 		});
 	});
 
+	describe('correct project config path', function () {
+		beforeAll(function () {
+			flexToolBar.configFilePath = path.resolve(__dirname, './fixtures/config/config.json');
+		});
+
+		it('should load toolbar.cson from specified path', function () {
+			atom.config.set('flex-tool-bar.toolBarProjectConfigurationFilePath', '.');
+			flexToolBar.resolveProjectConfigPath();
+			expect(flexToolBar.projectToolbarConfigPath).toBe(path.resolve(__dirname, './fixtures/toolbar.cson'));
+		});
+
+		it('should load specified config file', function () {
+			atom.config.set('flex-tool-bar.toolBarProjectConfigurationFilePath', './config/config.cson');
+			flexToolBar.resolveProjectConfigPath();
+			expect(flexToolBar.projectToolbarConfigPath).toBe(path.resolve(__dirname, './fixtures/config/config.cson'));
+		});
+
+		it('should not load if path equals global config file', function () {
+			atom.config.set('flex-tool-bar.toolBarProjectConfigurationFilePath', './config/config.json');
+			flexToolBar.resolveProjectConfigPath();
+			expect(flexToolBar.projectToolbarConfigPath).toBe(null);
+		});
+	});
+
 	if (!global.headless) {
 		// show linting errors in atom test window
 		describe('linting', function () {


### PR DESCRIPTION
The per project configuration file path can now be changed in the settings by specifying a path relative to the project root. It still defaults to the toolbar file in the project root.

Referring to #42 