### PR TITLE
Persistent project bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [next](https://github.com/cakecatz/flex-toolbar/compare/v0.14.0...master)
 -   Add project config path setting [#128](https://github.com/cakecatz/flex-toolbar/pull/128) (by [@malnvenshorn](https://github.com/malnvenshorn))
+-   Add persistent project tool bar setting [#129](https://github.com/cakecatz/flex-toolbar/pull/129) (by [@UziTech](https://github.com/UziTech))
 
 ## [v0.14.0](https://github.com/cakecatz/flex-toolbar/compare/v0.13.2...v0.14.0) - 2018-01-17
 -   Add package conditions [#126](https://github.com/cakecatz/flex-toolbar/pull/126) (by [@UziTech](https://github.com/UziTech))

--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -14,18 +14,22 @@ module.exports =
   watchList: []
 
   config:
+    persistentProjectToolBar:
+      description: 'Project tool bar will stay when focus is moved away from a project file'
+      type: 'boolean'
+      default: false
+    reloadToolBarNotification:
+      type: 'boolean'
+      default: true
+    reloadToolBarWhenEditConfigFile:
+      type: 'boolean'
+      default: true
     toolBarConfigurationFilePath:
       type: 'string'
       default: atom.getConfigDirPath()
     toolBarProjectConfigurationFilePath:
       type: 'string'
       default: '.'
-    reloadToolBarWhenEditConfigFile:
-      type: 'boolean'
-      default: true
-    reloadToolBarNotification:
-      type: 'boolean'
-      default: true
     useBrowserPlusWhenItIsActive:
       type: 'boolean'
       default: false
@@ -101,7 +105,8 @@ module.exports =
         return false
 
   resolveProjectConfigPath: ->
-    @projectToolbarConfigPath = null
+    persistent = atom.config.get 'flex-tool-bar.persistentProjectToolBar'
+    @projectToolbarConfigPath = null unless persistent
     relativeProjectConfigPath = atom.config.get 'flex-tool-bar.toolBarProjectConfigurationFilePath'
     editor = atom.workspace.getActivePaneItem()
     file = editor?.buffer?.file or editor?.file
@@ -113,7 +118,8 @@ module.exports =
           if fs.isFileSync(pathToCheck)
             @projectToolbarConfigPath = pathToCheck
           else
-            @projectToolbarConfigPath = fs.resolve pathToCheck, 'toolbar', ['cson', 'json5', 'json', 'js', 'coffee']
+            found = fs.resolve pathToCheck, 'toolbar', ['cson', 'json5', 'json', 'js', 'coffee']
+            @projectToolbarConfigPath = found if found
 
     if @projectToolbarConfigPath is @configFilePath
       @projectToolbarConfigPath = null

--- a/lib/flex-tool-bar.coffee
+++ b/lib/flex-tool-bar.coffee
@@ -196,10 +196,10 @@ module.exports =
       throw error
 
   fixToolBarHeight: ->
-    @getToolbarView().element.style.height = "#{@getToolbarView().element.offsetHeight}px"
+    @getToolbarView()?.element?.style.height = "#{@getToolbarView().element.offsetHeight}px"
 
   unfixToolBarHeight: ->
-    @getToolbarView().element.style.height = null
+    @getToolbarView()?.element?.style.height = null
 
   addButtons: (toolBarButtons) ->
     if toolBarButtons?
@@ -369,7 +369,7 @@ module.exports =
       return false
 
   removeButtons: ->
-    @toolBar.removeItems() if @toolBar?
+    @toolBar?.removeItems()
 
   deactivate: ->
     @watcherList.forEach (watcher) ->
@@ -378,5 +378,6 @@ module.exports =
     @subscriptions.dispose()
     @subscriptions = null
     @removeButtons()
+    @toolBar = null
 
   serialize: ->

--- a/spec/fixtures/project1/sample.js
+++ b/spec/fixtures/project1/sample.js
@@ -1,0 +1,2 @@
+/* eslint-disable  */
+undefined

--- a/spec/fixtures/project1/toolbar.cson
+++ b/spec/fixtures/project1/toolbar.cson
@@ -1,0 +1,8 @@
+[
+  {
+    type: "button"
+    icon: "octoface"
+    callback: "application:about"
+    tooltip: "project1"
+  }
+]

--- a/spec/fixtures/project2/sample.js
+++ b/spec/fixtures/project2/sample.js
@@ -1,0 +1,2 @@
+/* eslint-disable  */
+undefined

--- a/spec/flex-tool-bar-spec.js
+++ b/spec/flex-tool-bar-spec.js
@@ -208,26 +208,68 @@ describe('FlexToolBar', function () {
 
 	describe('persistent project tool bar', function () {
 		beforeEach(async function () {
-			atom.config.set('flex-tool-bar.toolBarProjectConfigurationFilePath', '.');
 			this.project1Config = path.join(__dirname, 'fixtures/project1/toolbar.cson');
+			this.project2Config = path.join(__dirname, 'fixtures/project2/toolbar.cson');
+			this.project1Sample = path.join(__dirname, 'fixtures/project1/sample.js');
+			this.project2Sample = path.join(__dirname, 'fixtures/project2/sample.js');
+			this.project3Sample = path.join(__dirname, 'fixtures/project3/sample.js');
+			this.settingsView = 'atom://config/packages/flex-toolbar';
+
+			await atom.packages.activatePackage('settings-view');
 			flexToolBar.projectToolbarConfigPath = null;
 			atom.project.setPaths([
 				path.join(__dirname, 'fixtures/project1/'),
 				path.join(__dirname, 'fixtures/project2/'),
+				path.join(__dirname, 'fixtures/project3/'),
 			]);
-
-			await atom.workspace.open(path.join(__dirname, 'fixtures/project1/sample.js'));
 		});
-		it('should disappear when not persistent and focus is not on the editor', async function () {
+		it('should not persistent when an editor is open that does not have a project config', async function () {
 			atom.config.set('flex-tool-bar.persistentProjectToolBar', false);
-			await atom.workspace.open(path.join(__dirname, 'fixtures/project2/sample.js'));
 
+			await atom.workspace.open(this.project1Sample);
+			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project1Config);
+
+			await atom.workspace.open(this.settingsView);
 			expect(flexToolBar.projectToolbarConfigPath).toBeNull();
-		});
-		it('should not disappear when persistent and focus is not on the editor', async function () {
-			atom.config.set('flex-tool-bar.persistentProjectToolBar', true);
-			await atom.workspace.open(path.join(__dirname, 'fixtures/project2/sample.js'));
 
+			await atom.workspace.open(this.project3Sample);
+			expect(flexToolBar.projectToolbarConfigPath).toBeNull();
+
+			await atom.workspace.open(this.project2Sample);
+			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project2Config);
+
+			await atom.workspace.open(this.settingsView);
+			expect(flexToolBar.projectToolbarConfigPath).toBeNull();
+
+			await atom.workspace.open(this.project3Sample);
+			expect(flexToolBar.projectToolbarConfigPath).toBeNull();
+
+			await atom.workspace.open(this.project1Sample);
+			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project1Config);
+		});
+
+		it('should persistent when an editor is open that does not have a project config', async function () {
+			atom.config.set('flex-tool-bar.persistentProjectToolBar', true);
+
+			await atom.workspace.open(this.project1Sample);
+			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project1Config);
+
+			await atom.workspace.open(this.settingsView);
+			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project1Config);
+
+			await atom.workspace.open(this.project3Sample);
+			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project1Config);
+
+			await atom.workspace.open(this.project2Sample);
+			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project2Config);
+
+			await atom.workspace.open(this.settingsView);
+			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project2Config);
+
+			await atom.workspace.open(this.project3Sample);
+			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project2Config);
+
+			await atom.workspace.open(this.project1Sample);
 			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project1Config);
 		});
 	});

--- a/spec/flex-tool-bar-spec.js
+++ b/spec/flex-tool-bar-spec.js
@@ -6,6 +6,9 @@ describe('FlexToolBar', function () {
 		await atom.packages.activatePackage('tool-bar');
 		await atom.packages.activatePackage('flex-tool-bar');
 	});
+	afterEach(async function () {
+		await atom.reset();
+	});
 
 	describe('activate', function () {
 		it('should store grammar', async function () {
@@ -180,26 +183,52 @@ describe('FlexToolBar', function () {
 	});
 
 	describe('correct project config path', function () {
-		beforeAll(function () {
+		beforeEach(function () {
 			flexToolBar.configFilePath = path.resolve(__dirname, './fixtures/config/config.json');
 		});
 
-		it('should load toolbar.cson from specified path', function () {
+		it('should load toolbar.cson from specified path', async function () {
 			atom.config.set('flex-tool-bar.toolBarProjectConfigurationFilePath', '.');
-			flexToolBar.resolveProjectConfigPath();
+			await atom.workspace.open(path.join(__dirname, 'fixtures/sample.js'));
 			expect(flexToolBar.projectToolbarConfigPath).toBe(path.resolve(__dirname, './fixtures/toolbar.cson'));
 		});
 
-		it('should load specified config file', function () {
+		it('should load specified config file', async function () {
 			atom.config.set('flex-tool-bar.toolBarProjectConfigurationFilePath', './config/config.cson');
-			flexToolBar.resolveProjectConfigPath();
+			await atom.workspace.open(path.join(__dirname, 'fixtures/sample.js'));
 			expect(flexToolBar.projectToolbarConfigPath).toBe(path.resolve(__dirname, './fixtures/config/config.cson'));
 		});
 
-		it('should not load if path equals global config file', function () {
+		it('should not load if path equals global config file', async function () {
 			atom.config.set('flex-tool-bar.toolBarProjectConfigurationFilePath', './config/config.json');
-			flexToolBar.resolveProjectConfigPath();
+			await atom.workspace.open(path.join(__dirname, 'fixtures/sample.js'));
 			expect(flexToolBar.projectToolbarConfigPath).toBe(null);
+		});
+	});
+
+	describe('persistent project tool bar', function () {
+		beforeEach(async function () {
+			atom.config.set('flex-tool-bar.toolBarProjectConfigurationFilePath', '.');
+			this.project1Config = path.join(__dirname, 'fixtures/project1/toolbar.cson');
+			flexToolBar.projectToolbarConfigPath = null;
+			atom.project.setPaths([
+				path.join(__dirname, 'fixtures/project1/'),
+				path.join(__dirname, 'fixtures/project2/'),
+			]);
+
+			await atom.workspace.open(path.join(__dirname, 'fixtures/project1/sample.js'));
+		});
+		it('should disappear when not persistent and focus is not on the editor', async function () {
+			atom.config.set('flex-tool-bar.persistentProjectToolBar', false);
+			await atom.workspace.open(path.join(__dirname, 'fixtures/project2/sample.js'));
+
+			expect(flexToolBar.projectToolbarConfigPath).toBeNull();
+		});
+		it('should not disappear when persistent and focus is not on the editor', async function () {
+			atom.config.set('flex-tool-bar.persistentProjectToolBar', true);
+			await atom.workspace.open(path.join(__dirname, 'fixtures/project2/sample.js'));
+
+			expect(flexToolBar.projectToolbarConfigPath).toBe(this.project1Config);
 		});
 	});
 

--- a/toolbar.cson
+++ b/toolbar.cson
@@ -1,0 +1,38 @@
+[
+  {
+    type: "url"
+    icon: "octoface"
+    url: "http://github.com"
+    tooltip: "Github Page"
+  }
+  {
+    type: "spacer"
+  }
+  {
+    type: "button"
+    icon: "document"
+    callback: "application:new-file"
+    tooltip: "New File"
+    iconset: "ion"
+    mode: "dev"
+  }
+  {
+    type: "button"
+    icon: "columns"
+    iconset: "fa"
+    callback: ["pane:split-right", "pane:split-right"]
+  }
+  {
+    type: "button"
+    icon: "circuit-board"
+    callback: "git-diff:toggle-diff-list"
+    style:
+      color: "#FA4F28"
+  }
+  {
+    type: "button"
+    icon: "markdown"
+    callback: "markdown-preview:toggle"
+    disable: "!markdown"
+  }
+]


### PR DESCRIPTION
Keep project bar visible when focus is moved off of a project editor

fixes #107